### PR TITLE
Migrate Hugo website to stable, eventually

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = 'https://bypass.beerpsi.me/beta'
+baseURL = 'https://bypass.beerpsi.me'
 languageCode = 'en-us'
 title = 'iOS Jailbreak Detection'
 theme = ["hugo-notice", "hugo-book"]


### PR DESCRIPTION
Related to hekatos/manifests#25.

Just changes the baseURL to remove the `/beta` suffix.